### PR TITLE
Fixes #4 - Do not log timestamps when running under systemd

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,10 @@ func createDirectory(path string) error {
 }
 
 func main() {
+	if os.Getenv("INVOCATION_ID") != "" {
+		log.SetFlags(0)
+	}
+
 	pin := flag.String("pin", defaultPin, "pin used to pair new sensors")
 	flag.Parse()
 


### PR DESCRIPTION
This patch disables timestamps in the standard logging module when it detects that the program is run under `systemd`.